### PR TITLE
Enable rotate after @bgstart

### DIFF
--- a/npc/custom/hBG/bg_common.txt
+++ b/npc/custom/hBG/bg_common.txt
@@ -103,6 +103,7 @@ OnInit:
 OnBGStartCommand:
 	setbattleflag .hBGEnabled$, 1;
 	message strcharinfo(0),"Battlegrounds have been enabled.";
+	donpcevent "BG_Queue_Handler::OnRotate";
 	callsub OnEndArena;
 OnBGStopCommand:
 	setbattleflag .hBGEnabled$, 0;


### PR DESCRIPTION
When battleflag **.hBGEnabled$ = 0**, rotation is automatic ended and cannot be resumed.
I added a **donpcevent** for restarting rotation.