### PR TITLE
Fixes target immunity in Bossnia

### DIFF
--- a/src/plugins/hBG.c
+++ b/src/plugins/hBG.c
@@ -4413,6 +4413,8 @@ HPExport void plugin_init(void)
 		addHookPost(chrif, save, chrif_save_post);
 		addHookPost(status, damage, status_damage_post);
 		
+		addHookPost( battle,check_target, battle_check_target_post );
+		
 		/* @Commands */
 		addAtcommand("bgrank", bgrank);
 		addAtcommand("reportafk", reportafk);

--- a/src/plugins/hBG.c
+++ b/src/plugins/hBG.c
@@ -3111,10 +3111,10 @@ BUILDIN(hBG_monster_immunity)
 
 	md = (TBL_MOB *)mbl;
 
-	if ((hBGmd = getFromMOBDATA(md, 0)) == NULL)
-		CREATE(hBGmd, struct hBG_mob_data, 1);
-	
-	addToMOBDATA(md, hBGmd, 0, true);
+	if ((hBGmd = getFromMOBDATA(md, 0)) == NULL){
+		CREATE(hBGmd, struct hBG_mob_data, 1);	
+		addToMOBDATA(md, hBGmd, 0, true);
+	}
 	hBGmd->state.immunity = flag;
 
 	return true;

--- a/src/plugins/hBG.c
+++ b/src/plugins/hBG.c
@@ -3113,7 +3113,8 @@ BUILDIN(hBG_monster_immunity)
 
 	if ((hBGmd = getFromMOBDATA(md, 0)) == NULL)
 		CREATE(hBGmd, struct hBG_mob_data, 1);
-
+	
+	addToMOBDATA(md, hBGmd, 0, true);
 	hBGmd->state.immunity = flag;
 
 	return true;
@@ -3871,6 +3872,22 @@ void battle_consume_ammo(struct map_session_data *sd, int skill_id, int lv)
 		if (sd->bg_id && map->list[sd->bl.m].flag.battleground)
 			add2limit(hBGsd->stats.ammo_used, qty, UINT_MAX);
 	}
+}
+// Check target immunity
+int battle_check_target_post( int retVal, struct block_list *src, struct block_list *target, int flag ) {
+
+	if ( retVal == 1 && target->type == BL_MOB ) {
+		struct hBG_mob_data *hBGmd;
+		if (( hBGmd = getFromMOBDATA( (TBL_MOB*)target, 0 ) ))
+		if ( hBGmd && hBGmd->state.immunity ){
+			hookStop();
+			return -1;
+		}
+
+        }
+
+        return retVal;
+
 }
 
 /**


### PR DESCRIPTION
Added Post-Hook for **battle_check_target**, now check if the target is immune. (state.immunity).

This change is related to BG Tierra Bossnia.