### PR TITLE
Added hBG_warp and hBG_team_warp

### DIFF
--- a/npc/custom/hBG/bg_ffa.txt
+++ b/npc/custom/hBG/bg_ffa.txt
@@ -46,7 +46,7 @@ OnReady:
 	set .Top,0;
 	sleep 2000;
 	for( set .@i, 0; .@i < 10; set .@i, .@i + 1) {
-		bg_warp $@FFA_Team[.@i],"RespawnPoint",0,0;
+		hBGg_warp $@FFA_Team[.@i],"RespawnPoint",0,0;
 	}
 	sleep 2000;
 	mapannounce "bat_c01","-- Free For All - Starting in 10 seconds --",1,0x483D8B;

--- a/npc/custom/hBG/bg_rush.txt
+++ b/npc/custom/hBG/bg_rush.txt
@@ -113,13 +113,13 @@ OnEmperium:
 		if (.dfndr == $@BG_Team1) {
 			set .guill_score,1;
 			mapannounce .rush_castle$,"General Guillaume : Castle captured, now prepare to Defend it!!",1,0x0000FF;
-			bg_warp $@BG_Team2,"RespawnPoint",0,0; // To Cementery and Wait
+			hBG_warp $@BG_Team2,"RespawnPoint",0,0; // To Cementery and Wait
 		}
 		else
 		{
 			set .croix_score,1;
 			mapannounce .rush_castle$,"Prince Croix : Castle captured, now prepare to Defend it!!",1,0xFF0000;
-			bg_warp $@BG_Team1,"RespawnPoint",0,0; // To Cementery and Wait
+			hBG_warp $@BG_Team1,"RespawnPoint",0,0; // To Cementery and Wait
 		}
 
 		hBG_updatescore .rush_castle$,.guill_score,.croix_score;

--- a/src/plugins/hBG.c
+++ b/src/plugins/hBG.c
@@ -2073,6 +2073,26 @@ void hBG_record_damage(struct block_list *src, struct block_list *target, int da
 	}
 }
 
+/**
+ * Warps a Team
+ * @see hBG_warp
+ */
+int hBG_team_warp(int bg_id, unsigned short mapindex, short x, short y)
+{ // Warps a Team
+	int i;
+	struct battleground_data *bgd = bg->team_search(bg_id);
+	if( bgd == NULL ) return false;
+	if( mapindex == 0 )
+	{
+		mapindex = bgd->mapindex;
+		x = bgd->x;
+		y = bgd->y;
+	}
+
+	for( i = 0; i < MAX_BG_MEMBERS; i++ )
+		if( bgd->members[i].sd != NULL ) pc->setpos(bgd->members[i].sd, mapindex, x, y, CLR_TELEPORT);
+	return true;
+}
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *                     @Commands
@@ -3560,6 +3580,29 @@ BUILDIN(hBG_flooritem2xy)
 
 	return true;
 }
+/**
+ * Warps BG Team to destination or Respawn Point
+ * @param BG Team
+ * @param Map Name
+ * @param Map X
+ * @param Map Y
+ */
+BUILDIN(hBG_warp)
+{
+	int x, y, mapindex, bg_id;
+	const char* map_name;
+
+	bg_id = script_getnum(st,2);
+	map_name = script_getstr(st,3);
+	if( !strcmp(map_name,"RespawnPoint") ) // Cementery Zone
+		mapindex = 0;
+	else if( (mapindex = script->mapindexname2id(st,map_name)) == 0 )
+		return 0; // Invalid Map
+	x = script_getnum(st,4);
+	y = script_getnum(st,5);
+	bg_id = hBG_team_warp(bg_id, mapindex, x, y);
+	return true;
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
@@ -4435,6 +4478,7 @@ HPExport void plugin_init(void)
 		addScriptCommand("hBG_getkafrapoints","ii", hBG_getkafrapoints);
 		addScriptCommand("hBG_reward","iiiiisiii", hBG_reward);
 		addScriptCommand("hBG_flooritem2xy", "siiii", hBG_flooritem2xy);
+		addScriptCommand("hBG_warp", "isii", hBG_warp);
 		
 		hBG_queue_db = idb_alloc(DB_OPT_RELEASE_DATA);
 		timer->add_func_list(hBG_send_xy_timer, "hBG_send_xy_timer");


### PR DESCRIPTION
- Added hBG_warp and hBG_team_warp
- Fixes bg_warp for destination map "RespawnPoint", now teleport teams correctly to Cementery/Respawn zone.
However, it's necessary to replace "bg_warp" to "hBG_warp" (at least in "RespawnPoint" cases).