### PR TITLE
Fixes and new commands

### DIFF
--- a/conf/map/battle/hBG.conf
+++ b/conf/map/battle/hBG.conf
@@ -61,3 +61,7 @@ hBG_xy_interval: 1000
 // Enable ranked mode battlegrounds.
 // (Note 1)
 hBG_ranked_mode: 1
+
+// Enable @leader command.
+// (Note 1)
+hBG_leader_change: 1

--- a/npc/custom/hBG/bg_common.txt
+++ b/npc/custom/hBG/bg_common.txt
@@ -65,7 +65,8 @@ OnInit:
 	setarray .BG_Players_Max[0],        35,              35,             35,              35,           35,          50,            35,            35,           30;
 	// Battleground announcement colors.
 	setarray .BG_Color$[0],         "0x2F9F2D",      "0xAA00FF",      "0xFF0033",     "0x33FF99",   "0x3399FF",  "0xFFA500",    "0x9ACD32",    "0x4169E1",   "0xDDA0DD";
-
+	// Battleground @bgmode interger colors.
+	setarray .BG_Color2[0],         0x2F9F2D,      0xAA00FF,      0xFF0033,     0x33FF99,   0x3399FF,  0xFFA500,    0x9ACD32,    0x4169E1,   0xDDA0DD,  0x00FF00;
 	// Team Building Mode :
 	// 0 = Lineal [Keeps parties together]
 	// 1 = Random
@@ -81,6 +82,8 @@ OnInit:
 		/* Admin / GM Commands */
 		bindatcmd "bgstart","BG_Queue_Handler::OnBGStartCommand",99,99;
 		bindatcmd "bgstop","BG_Queue_Handler::OnBGStopCommand",99,99;
+		bindatcmd "bgmode","BG_Queue_Handler::OnBGModeCommand",99,99;
+		bindatcmd "bgsize","BG_Queue_Handler::OnBGSizeCommand",99,99;
 		/* Player Commands */
 		bindatcmd "joinbg","BG_Queue_Handler::OnDoJoin",0,99;
 		bindatcmd "leavebg","BG_Queue_Handler::OnDoLeave",0,99;
@@ -99,7 +102,52 @@ OnInit:
 	initnpctimer; // Initiate rotation timer.
 	.hBGEnabled$ = "battle_configuration/hBG_enabled";
 	end;
-
+	
+// @bgmode <1-10>
+OnBGModeCommand:
+	.@x = atoi(.@atcmd_parameters$[0]);
+	if (.@x <= .TotalArenas+1 && .@x > 0) {
+		if (.@x == 1)
+			set $BG_Index, rand(.TotalArenas)-1;
+		else
+			set $BG_Index, .@x-3;
+		message strcharinfo(0),"["+.BG_Names$[$BG_Index+1]+"] has been set.";
+		donpcevent "BG_Queue_Handler::OnRotate";
+		end;
+	} else {
+		message strcharinfo(0), "Usage: @bgmode <1-"+(.TotalArenas+1)+">";
+		dispbottom "#1 - Random",0xFFFFFF;
+		for (.@i = 0; .@i<.TotalArenas; .@i++)
+			dispbottom "#"+(.@i+2)+" - "+.BG_Names$[.@i],.BG_Color2[.@i];			
+		end;
+	}
+		
+// @bgsize <1-10> <min> <max>
+OnBGSizeCommand:
+	.@x = atoi(.@atcmd_parameters$[0]);
+	.@x2 = atoi(.@atcmd_parameters$[1]);
+	.@x3 = atoi(.@atcmd_parameters$[2]);
+	if (.@x2 == 0 || .@x3 == 0) {
+		message strcharinfo(0), "Usage: @bgsize <0-"+.TotalArenas+"> <min players> <max players>";
+		dispbottom "#0 - All Arenas",0xFFFFFF;
+		for (.@i = 0; .@i<.TotalArenas; .@i++)
+			dispbottom "#"+(.@i+1)+" - "+.BG_Names$[.@i],.BG_Color2[.@i];			
+		end;
+	} else if (.@x2 > .@x3) {
+		message strcharinfo(0), "@bgsize failed: min players is higher than max players. ";
+		end;
+	}	
+	if (.@x <= .TotalArenas && .@x > 0) {
+		message strcharinfo(0),"["+.BG_Names$[.@x-1]+"] min players is <"+.@x2+"> and max players is <"+.@x3+">.";
+		setarray .BG_Players_Min[.@x-1],.@x2;
+		setarray .BG_Players_Max[.@x-1],.@x3;
+	} else {
+		message strcharinfo(0),"[All Arenas] min players is <"+.@x2+"> and max players is <"+.@x3+">.";
+		setarray .BG_Players_Min[0],.@x2,.@x2,.@x2,.@x2,.@x2,.@x2,.@x2,.@x2,.@x2;
+		setarray .BG_Players_Max[0],.@x3,.@x3,.@x3,.@x3,.@x3,.@x3,.@x3,.@x3,.@x3;
+	}
+	end;
+		
 OnBGStartCommand:
 	setbattleflag .hBGEnabled$, 1;
 	message strcharinfo(0),"Battlegrounds have been enabled.";
@@ -132,6 +180,10 @@ OnDoJoin:
 // @leavebg
 OnDoLeave:
 	hBG_queue_leave .BG_Queue;
+	if (getmapflag(strcharinfo(3),mf_battleground)) {
+		hBG_leave;
+		warp "SavePoint", 0, 0;
+	}
 	end;
 
 // Triggers after an arena has ended.

--- a/src/plugins/hBG.c
+++ b/src/plugins/hBG.c
@@ -149,7 +149,8 @@ int hBG_idle_announce,
 	hBG_ip_check,
 	hBG_from_town_only,
 	hBG_enabled,
-	hBG_xy_interval;
+	hBG_xy_interval,
+	hBG_leader_change;
 
 /**
  * BG Fame list types
@@ -2174,6 +2175,52 @@ ACMD(reportafk)
 	return false;
 }
 
+/**
+ * Change Team Leader.
+ */
+ACMD(leader)
+{
+	struct map_session_data *pl_sd = NULL;
+	struct hBG_data *hBGd = NULL;
+	struct hBG_map_session_data *hBGsd = NULL;
+	struct hBG_map_session_data *hBGpl_sd = NULL;
+	struct battleground_data *bgd = NULL;
+	
+	if ((hBGsd = getFromMSD(sd, 1)) == NULL) {
+		clif->message(fd, "You are not in battlegrounds.");
+		return false;
+	}
+	
+	if ((bgd = bg->team_search(sd->bg_id)) == NULL || (hBGd = getFromBGDATA(bgd, 0)) == NULL)
+		clif->message(fd, "This command is reserved for Battlegrounds Only.");
+	if( sd->ud.skilltimer != INVALID_TIMER )
+		clif->message(fd, "Command not allow while casting a skill.");
+	else if (!(hBG_config_get("battle_configuration/hBG_leader_change")))
+		clif->message(fd, "This command is disabled.");
+	else if (!(hBGd->leader_char_id == sd->status.char_id))
+		clif->message(fd, "This command is reserved for Team Leaders Only.");
+	else if (!*message)
+		clif->message(fd, "Please, enter the character name (usage: @leader <name>).");
+	else if ((pl_sd = map->nick2sd(message)) == NULL)
+		clif->message(fd, msg_txt(3)); // Character not found.
+	else if ((hBGpl_sd = getFromMSD(pl_sd, 0)) == NULL)
+		clif->message(fd, "Destination Player is not in battlegrounds.");
+	else if (sd->bg_id != pl_sd->bg_id)
+		clif->message(fd, "Destination Player is not in your Team.");
+	else if (sd == pl_sd)
+		clif->message(fd, "You are already the Team Leader.");
+	else
+	{ // Everytest OK!
+		char atcmd_output[256];
+		sprintf(atcmd_output, "Team Leader transfered to [%s]", pl_sd->status.name);
+		clif->broadcast2(&sd->bl, atcmd_output, (int)strlen(atcmd_output)+1, hBGd->color, 0x190, 20, 0, 0, BG);
+		hBGd->leader_char_id = pl_sd->status.char_id;
+		clif->charnameupdate(sd);
+		clif->charnameupdate(pl_sd);
+		return true;
+	}
+	return false;
+}
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *                     Script Commands
@@ -3665,6 +3712,13 @@ void clif_charnameupdate_pre(struct map_session_data **sd)
 
 	hookStop();
 }
+//Prevent update Guild Info if you're in BG
+void clif_parse_GuildRequestInfo_pre(int *fd, struct map_session_data **sd)
+{
+	if ((*sd) && (*sd)->bg_id)
+		hookStop();
+	return;
+}
 
 /**
  * Skill Pre-Hooks.
@@ -3681,9 +3735,30 @@ int skill_check_condition_castbegin_pre(struct map_session_data **sd, uint16 *sk
 
 int skillnotok_pre(uint16 *skill_id, struct map_session_data **sd)
 {
-	if (map->list[(*sd)->bl.m].flag.battleground && *skill_id >= GD_SKILLBASE && *skill_id <= GD_DEVELOPMENT)
-		hookStop();
+	int16 idx, m;
+	nullpo_retr(1, *sd);
+	m = (*sd)->bl.m;
+	idx = skill->get_index(*skill_id);
+ 
+	if (map->list[m].flag.battleground && (*skill_id >= GD_SKILLBASE && *skill_id <= GD_DEVELOPMENT)) {
 	
+		if (pc_has_permission(*sd, PC_PERM_DISABLE_SKILL_USAGE)) {
+			hookStop();
+			return 1;
+		}
+
+		if (pc_has_permission(*sd, PC_PERM_SKILL_UNCONDITIONAL)) {
+			hookStop();
+			return 0; // can do any damn thing they want
+		}
+
+		if ((*sd)->blockskill[idx]) {
+			clif->skill_fail((*sd), *skill_id, USESKILL_FAIL_SKILLINTERVAL, 0);
+			hookStop();
+			return 1;
+		}
+		hookStop();
+	}
 	return 0;
 }
 
@@ -3951,7 +4026,15 @@ void clif_parse_LoadEndAck_post(int fd, struct map_session_data *sd)
 	clif->charnameupdate(sd);
 	return;
 }
-
+//Send charname_update every time you see someone in BG
+void clif_getareachar_unit_post(struct map_session_data *sd, struct block_list *bl)
+{
+	if (bl->type == BL_PC) {
+		struct map_session_data *tsd = BL_CAST(BL_PC, bl);
+		clif->charnameupdate(tsd);
+		return;
+	}
+}
 void clif_parse_UseSkillToId_post(int fd, struct map_session_data *sd)
 {
 	uint16 skill_id;
@@ -4398,6 +4481,13 @@ void hBG_config_read(const char *key, const char *val)
 		} else {
 			hBG_ranked_mode = value;
 		}
+	} else if (strcmpi(key, "battle_configuration/hBG_leader_change") == 0) {
+		if (value < 0 || value > 1) {
+			ShowWarning("Received Invalid Setting %d for hBG_leader_change, defaulting to 0.\n", value);
+			hBG_leader_change = 0;
+		} else {
+			hBG_leader_change = value;
+		}
 	}
 }
 
@@ -4423,6 +4513,8 @@ int hBG_config_get(const char *key)
 		return hBG_xy_interval;
 	else if (strcmpi(key, "battle_configuration/hBG_ranked_mode") == 0)
 		return hBG_ranked_mode;
+	else if (strcmpi(key, "battle_configuration/hBG_leader_change") == 0)
+		return hBG_leader_change;
 
 	return 0;
 }
@@ -4448,6 +4540,7 @@ HPExport void plugin_init(void)
 		/* Function Pre-Hooks */
 		addHookPre(npc, parse_unknown_mapflag, npc_parse_unknown_mapflag_pre);
 		addHookPre(clif, charnameupdate, clif_charnameupdate_pre);
+		addHookPre(clif, pGuildRequestInfo,clif_parse_GuildRequestInfo_pre);
 		addHookPre(status, get_guild_id, status_get_guild_id_pre);
 		addHookPre(status, get_emblem_id, status_get_emblem_id_pre);
 		addHookPre(guild, isallied, guild_isallied_pre);
@@ -4462,6 +4555,7 @@ HPExport void plugin_init(void)
 		addHookPost(clif, pLoadEndAck, clif_parse_LoadEndAck_post);
 		addHookPost(clif, pUseSkillToId, clif_parse_UseSkillToId_post);
 		addHookPost(clif, getareachar_pc, clif_getareachar_pc_post);
+		addHookPost(clif, getareachar_unit, clif_getareachar_unit_post);
 		addHookPost(pc, update_idle_time, pc_update_idle_time_post);
 		addHookPost(pc, authok, pc_authok_post);
 		addHookPost(chrif, save, chrif_save_post);
@@ -4472,6 +4566,7 @@ HPExport void plugin_init(void)
 		/* @Commands */
 		addAtcommand("bgrank", bgrank);
 		addAtcommand("reportafk", reportafk);
+		addAtcommand("leader", leader);
 		
 		/* Script Commands */
 		addScriptCommand("hBG_team_create","siiiss", hBG_team_create);
@@ -4529,6 +4624,7 @@ HPExport void server_preinit(void)
 		addBattleConf("battle_configuration/hBG_reward_rates", hBG_config_read, hBG_config_get, true);
 		addBattleConf("battle_configuration/hBG_xy_interval", hBG_config_read, hBG_config_get, true);
 		addBattleConf("battle_configuration/hBG_ranked_mode", hBG_config_read, hBG_config_get, true);
+		addBattleConf("battle_configuration/hBG_leader_change", hBG_config_read, hBG_config_get, true);
 	}
 }
 


### PR DESCRIPTION
- Fixed GD Skills cooldown.
- Added 3 new commands:

@leader <char name>
This command allows to change the team leader. (Include BattleConf parameter)

@bgmode <1 - 10 > (TotalArenas)
Set a bg mode as new queue.
Number 1 = Random Mode.

@bgsize <0 - 9> <min players> <max players>
Set players requeriments for a specific mode.
Number 0 = All Arenas.

@leave now allows leave BG.

Updates 05/15

- Fixed Guild Information:
If you entering in BG being in a guild, your guild info (name, leader, skill, etc) overrides "BG Guild Info", now It's solved.

- Fixed charname display:
When you enter to bg arenas, your name is changed to your team info, eg.

Easycore
Blue Team [Blue Team Leader]

But this change only was showed once in LoadMap. Now it's always is displayed.

- Added team emblem and removed sword emblem:
For enable this feature you must set "EnableEmblemForBG" in your exe diff.

You can find this patch in this NEMO tree:
https://github.com/MStr3am/NEMO/tree/fc064112e0704e06c6746e871fbe4df35d18740e
Just download and execute.